### PR TITLE
Changing the file structure of WinCairo libraries

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -7,7 +7,7 @@
     <OutDir>$(SolutionDir)bin32\</OutDir>
     <IntDir>$(SolutionDir)Build\$(Configuration)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)lib32;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(SolutionDir)lib\x86;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Bscmake>
@@ -26,13 +26,13 @@
       <AdditionalIncludeDirectories>$(ProjectDir)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(SolutionDir)lib32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>false</GenerateMapFile>
       <MapExports>false</MapExports>
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <DataExecutionPrevention>true</DataExecutionPrevention>
-      <ImportLibrary>$(SolutionDir)lib32/$(TargetName).lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x86/$(TargetName).lib</ImportLibrary>
       <TargetMachine>MachineX86</TargetMachine>
       <SubSystem>Windows</SubSystem>
       <FixedBaseAddress>false</FixedBaseAddress>

--- a/props/common_x64.props
+++ b/props/common_x64.props
@@ -7,7 +7,7 @@
     <OutDir>$(SolutionDir)bin64\</OutDir>
     <IntDir>$(SolutionDir)Build\$(Configuration)\$(ProjectName)\x64\</IntDir>
     <IncludePath>$(SolutionDir)include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)lib64;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(SolutionDir)lib\x64;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Bscmake>
@@ -26,13 +26,13 @@
       <AdditionalIncludeDirectories>$(ProjectDir)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(SolutionDir)lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>false</GenerateMapFile>
       <MapExports>false</MapExports>
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <DataExecutionPrevention>true</DataExecutionPrevention>
-      <ImportLibrary>$(SolutionDir)lib64/$(TargetName).lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x64/$(TargetName).lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
       <SubSystem>Windows</SubSystem>
       <FixedBaseAddress>false</FixedBaseAddress>

--- a/props/lib.props
+++ b/props/lib.props
@@ -2,14 +2,14 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir>$(SolutionDir)lib32\</OutDir>
+    <OutDir>$(SolutionDir)lib\x86\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Lib>
-      <OutputFile>$(SolutionDir)lib32/$(TargetName)$(TargetExt)</OutputFile>
+      <OutputFile>$(SolutionDir)lib\x86/$(TargetName)$(TargetExt)</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
 </Project>

--- a/props/lib_x64.props
+++ b/props/lib_x64.props
@@ -2,14 +2,14 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir>$(SolutionDir)lib64\</OutDir>
+    <OutDir>$(SolutionDir)lib\x64\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Lib>
-      <OutputFile>$(SolutionDir)lib64/$(TargetName)$(TargetExt)</OutputFile>
+      <OutputFile>$(SolutionDir)lib\x64/$(TargetName)$(TargetExt)</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
 </Project>

--- a/src/cairo/cairo/src/cairo.vcxproj
+++ b/src/cairo/cairo/src/cairo.vcxproj
@@ -103,17 +103,17 @@
       <AdditionalDependencies>Msimg32.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)..\cairo-version.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-deprecated.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-features.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-gl.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-pdf.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-ps.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-svg.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-win32.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include\cairo"
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\cairo-version.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-deprecated.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-features.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-gl.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-pdf.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-ps.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-svg.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-win32.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include"
 </Command>
       <Message>Install Headers</Message>
     </PostBuildEvent>
@@ -130,17 +130,17 @@ xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include\cairo"
       <AdditionalDependencies>Msimg32.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)..\cairo-version.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-deprecated.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-features.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-gl.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-pdf.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-ps.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-svg.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-win32.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include\cairo"
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\cairo-version.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-deprecated.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-features.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-gl.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-pdf.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-ps.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-svg.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-win32.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include"
 </Command>
       <Message>Install Headers</Message>
     </PostBuildEvent>
@@ -158,17 +158,17 @@ xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include\cairo"
       </ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)..\cairo-version.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-deprecated.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-features.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-gl.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-pdf.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-ps.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-svg.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-win32.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include\cairo"
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\cairo-version.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-deprecated.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-features.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-gl.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-pdf.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-ps.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-svg.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-win32.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include"
 </Command>
       <Message>Install Headers</Message>
     </PostBuildEvent>
@@ -185,17 +185,17 @@ xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include\cairo"
       </ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)..\cairo-version.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-deprecated.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-features.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-gl.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-pdf.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-ps.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-svg.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-win32.h" "$(SolutionDir)include\cairo"
-xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include\cairo"
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\cairo-version.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-deprecated.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-features.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-gl.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-pdf.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-ps.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-svg.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-win32.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cairo-xml.h" "$(SolutionDir)include"
 </Command>
       <Message>Install Headers</Message>
     </PostBuildEvent>

--- a/src/cairo/cairo/test/cairotest/cairotest.cpp
+++ b/src/cairo/cairo/test/cairotest/cairotest.cpp
@@ -26,8 +26,8 @@
 #include <windows.h>
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include "cairo/cairo-gl.h"
-#include "cairo/cairo-win32.h"
+#include "cairo-gl.h"
+#include "cairo-win32.h"
 
 #define MAX_LOADSTRING 100
 

--- a/src/curl/lib/libcurl.vcxproj
+++ b/src/curl/lib/libcurl.vcxproj
@@ -108,7 +108,7 @@
     <ResourceCompile />
     <Link>
       <AdditionalDependencies>ws2_32.lib;wldap32.lib;libeay32.lib;ssleay32.lib;Advapi32.lib</AdditionalDependencies>
-      <ImportLibrary>$(SolutionDir)lib32/$(TargetName)_imp.lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x86/$(TargetName)_imp.lib</ImportLibrary>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
@@ -135,7 +135,7 @@ xcopy /Y /R "$(ProjectDir)..\include\curl\*.h" "$(SolutionDir)include\curl\"</Co
     <ResourceCompile />
     <Link>
       <AdditionalDependencies>ws2_32.lib;wldap32.lib;libeay32.lib;ssleay32.lib;Advapi32.lib</AdditionalDependencies>
-      <ImportLibrary>$(SolutionDir)lib64/$(TargetName)_imp.lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x64/$(TargetName)_imp.lib</ImportLibrary>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
@@ -163,7 +163,7 @@ xcopy /Y /R "$(ProjectDir)..\include\curl\*.h" "$(SolutionDir)include\curl\"</Co
     <ResourceCompile />
     <Link>
       <AdditionalDependencies>ws2_32.lib;wldap32.lib;libeay32.lib;ssleay32.lib;Advapi32.lib</AdditionalDependencies>
-      <ImportLibrary>$(SolutionDir)lib32/$(TargetName)_imp.lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x86/$(TargetName)_imp.lib</ImportLibrary>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
@@ -193,7 +193,7 @@ xcopy /Y /R "$(ProjectDir)..\include\curl\*.h" "$(SolutionDir)include\curl\"</Co
     <ResourceCompile />
     <Link>
       <AdditionalDependencies>ws2_32.lib;wldap32.lib;libeay32.lib;ssleay32.lib;Advapi32.lib</AdditionalDependencies>
-      <ImportLibrary>$(SolutionDir)lib64/$(TargetName)_imp.lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x64/$(TargetName)_imp.lib</ImportLibrary>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>

--- a/src/icu/source/common/common.vcxproj
+++ b/src/icu/source/common/common.vcxproj
@@ -168,7 +168,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\icuuc.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\icuuc.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <PreprocessorDefinitions>U_ATTRIBUTE_DEPRECATED=;WIN64;WIN32;NDEBUG;_CRT_SECURE_NO_DEPRECATE;U_COMMON_IMPLEMENTATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -191,10 +191,10 @@
     <Link>
       <OutputFile>..\..\bin64\icuuc56.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <ProgramDatabaseFile>.\..\..\lib64\icuuc.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\icuuc.pdb</ProgramDatabaseFile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <BaseAddress>0x4a800000</BaseAddress>
-      <ImportLibrary>..\..\lib64\icuuc.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icuuc.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent />
@@ -205,7 +205,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\icuucd.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\icuucd.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -232,9 +232,9 @@
       <OutputFile>..\..\bin64\icuuc56d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\..\..\lib64\icuucd.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\icuucd.pdb</ProgramDatabaseFile>
       <BaseAddress>0x4a800000</BaseAddress>
-      <ImportLibrary>..\..\lib64\icuucd.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icuucd.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent />

--- a/src/icu/source/i18n/i18n.vcxproj
+++ b/src/icu/source/i18n/i18n.vcxproj
@@ -180,7 +180,7 @@ xcopy /Y /R "$(ProjectDir)..\..\include\unicode\*.h" "$(SolutionDir)include\unic
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\icuin.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\icuin.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\include;..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -206,10 +206,10 @@ xcopy /Y /R "$(ProjectDir)..\..\include\unicode\*.h" "$(SolutionDir)include\unic
     <Link>
       <OutputFile>..\..\bin64\icuin56.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <ProgramDatabaseFile>.\..\..\lib64\icuin.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\icuin.pdb</ProgramDatabaseFile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <BaseAddress>0x4a900000</BaseAddress>
-      <ImportLibrary>..\..\lib64\icuin.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icuin.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent>
@@ -223,7 +223,7 @@ xcopy /Y /R "$(ProjectDir)..\..\include\unicode\*.h" "$(SolutionDir)include\unic
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\icuind.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\icuind.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -253,9 +253,9 @@ xcopy /Y /R "$(ProjectDir)..\..\include\unicode\*.h" "$(SolutionDir)include\unic
       <OutputFile>..\..\bin64\icuin56d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\..\..\lib64\icuind.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\icuind.pdb</ProgramDatabaseFile>
       <BaseAddress>0x4a900000</BaseAddress>
-      <ImportLibrary>..\..\lib64\icuind.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icuind.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent>

--- a/src/icu/source/io/io.vcxproj
+++ b/src/icu/source/io/io.vcxproj
@@ -172,7 +172,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\icuio.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\icuio.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\include;..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -198,10 +198,10 @@
     <Link>
       <OutputFile>..\..\bin64\icuio56.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <ProgramDatabaseFile>.\..\..\lib64\icuio.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\icuio.pdb</ProgramDatabaseFile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <BaseAddress>0x4ab00000</BaseAddress>
-      <ImportLibrary>..\..\lib64\icuio.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icuio.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
@@ -211,7 +211,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\icuio.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\icuio.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -241,9 +241,9 @@
       <OutputFile>..\..\bin64\icuio56d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\..\..\lib64\icuiod.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\icuiod.pdb</ProgramDatabaseFile>
       <BaseAddress>0x4ab00000</BaseAddress>
-      <ImportLibrary>..\..\lib64\icuiod.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icuiod.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>

--- a/src/icu/source/layout/layout.vcxproj
+++ b/src/icu/source/layout/layout.vcxproj
@@ -172,7 +172,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\iculed.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\iculed.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -202,9 +202,9 @@
       <OutputFile>..\..\bin64\icule56d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\..\..\lib64\iculed.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\iculed.pdb</ProgramDatabaseFile>
       <BaseAddress>0x4ac00000</BaseAddress>
-      <ImportLibrary>..\..\lib64\iculed.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\iculed.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
@@ -214,7 +214,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\icule.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\icule.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\include;..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -240,10 +240,10 @@
     <Link>
       <OutputFile>..\..\bin64\icule56.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <ProgramDatabaseFile>.\..\..\lib64\icule.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\icule.pdb</ProgramDatabaseFile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <BaseAddress>0x4ac00000</BaseAddress>
-      <ImportLibrary>..\..\lib64\icule.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icule.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>

--- a/src/icu/source/layoutex/layoutex.vcxproj
+++ b/src/icu/source/layoutex/layoutex.vcxproj
@@ -169,7 +169,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\iculx.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\iculx.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\include;..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -193,10 +193,10 @@
     <Link>
       <OutputFile>..\..\bin64\iculx56.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <ProgramDatabaseFile>.\..\..\lib64\iculx.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\iculx.pdb</ProgramDatabaseFile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <BaseAddress>0x4ac80000</BaseAddress>
-      <ImportLibrary>..\..\lib64\iculx.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\iculx.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
@@ -206,7 +206,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\lib64\iculxd.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\lib\x64\iculxd.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -234,9 +234,9 @@
       <OutputFile>..\..\bin64\iculx56d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\..\..\lib64\iculxd.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\lib\x64\iculxd.pdb</ProgramDatabaseFile>
       <BaseAddress>0x4ac80000</BaseAddress>
-      <ImportLibrary>..\..\lib64\iculxd.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\iculxd.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>

--- a/src/icu/source/samples/break/break.vcxproj
+++ b/src/icu/source/samples/break/break.vcxproj
@@ -153,7 +153,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/break.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/break.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -239,7 +239,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/break.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/break.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/samples/cal/cal.vcxproj
+++ b/src/icu/source/samples/cal/cal.vcxproj
@@ -150,7 +150,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/cal.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/cal.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -231,7 +231,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/cal.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/cal.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/samples/case/case.vcxproj
+++ b/src/icu/source/samples/case/case.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;icuiod.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/case.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/case.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;icuio.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/case.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/case.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/citer/citer.vcxproj
+++ b/src/icu/source/samples/citer/citer.vcxproj
@@ -121,7 +121,7 @@
     <Link>
       <AdditionalDependencies>icuucd.lib;icuind.lib;icuiod.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>./Debug/citer.exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)citer.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -173,7 +173,7 @@
     <Link>
       <AdditionalDependencies>icuuc.lib;icuin.lib;icuio.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>./Release/citer.exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/src/icu/source/samples/coll/coll.vcxproj
+++ b/src/icu/source/samples/coll/coll.vcxproj
@@ -146,7 +146,7 @@
       <AdditionalDependencies>icuind.lib;icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/coll.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/coll.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -227,7 +227,7 @@
       <AdditionalDependencies>icuind.lib;icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/coll.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/coll.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/samples/csdet/csdet.vcxproj
+++ b/src/icu/source/samples/csdet/csdet.vcxproj
@@ -121,7 +121,7 @@
     <Link>
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)csdet.exe</OutputFile>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)csdet.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -173,7 +173,7 @@
     <Link>
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)csdet.exe</OutputFile>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/src/icu/source/samples/date/date.vcxproj
+++ b/src/icu/source/samples/date/date.vcxproj
@@ -150,7 +150,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/date.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/date.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -229,7 +229,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/date.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/date.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/samples/datefmt/datefmt.vcxproj
+++ b/src/icu/source/samples/datefmt/datefmt.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/datefmt.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/datefmt.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/datefmt.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/datefmt.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/layout/layout.vcxproj
+++ b/src/icu/source/samples/layout/layout.vcxproj
@@ -142,7 +142,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\lib64\iculx.lib;..\..\..\lib64\icule.lib;..\..\..\lib64\icuuc.lib;..\..\..\lib64\icuin.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\lib\x64\iculx.lib;..\..\..\lib\x64\icule.lib;..\..\..\lib\x64\icuuc.lib;..\..\..\lib\x64\icuin.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/layout.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ProgramDatabaseFile>.\x64\Release/layout.pdb</ProgramDatabaseFile>
@@ -219,7 +219,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\lib64\iculxd.lib;..\..\..\lib64\iculed.lib;..\..\..\lib64\icuucd.lib;..\..\..\lib64\icuind.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\lib\x64\iculxd.lib;..\..\..\lib\x64\iculed.lib;..\..\..\lib\x64\icuucd.lib;..\..\..\lib\x64\icuind.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/layout.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/icu/source/samples/msgfmt/msgfmt.vcxproj
+++ b/src/icu/source/samples/msgfmt/msgfmt.vcxproj
@@ -146,7 +146,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/msgfmt.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/msgfmt.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -225,7 +225,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/msgfmt.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/msgfmt.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/samples/numfmt/numfmt.vcxproj
+++ b/src/icu/source/samples/numfmt/numfmt.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/numfmt.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/numfmt.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/numfmt.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/numfmt.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/props/props.vcxproj
+++ b/src/icu/source/samples/props/props.vcxproj
@@ -146,7 +146,7 @@
       <AdditionalDependencies>icuuc.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/props.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/props.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -225,7 +225,7 @@
       <AdditionalDependencies>icuucd.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/props.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/props.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/samples/strsrch/strsrch.vcxproj
+++ b/src/icu/source/samples/strsrch/strsrch.vcxproj
@@ -149,7 +149,7 @@
       <AdditionalDependencies>icuind.lib;icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/strsrch.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/strsrch.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -228,7 +228,7 @@
       <AdditionalDependencies>icuin.lib;icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/strsrch.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/strsrch.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/translit/translit.vcxproj
+++ b/src/icu/source/samples/translit/translit.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/translit.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/translit.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/translit.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/translit.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/uciter8/uciter8.vcxproj
+++ b/src/icu/source/samples/uciter8/uciter8.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/uciter8.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/uciter8.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/uciter8.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/uciter8.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/ucnv/ucnv.vcxproj
+++ b/src/icu/source/samples/ucnv/ucnv.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/ucnv.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/ucnv.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icuuc.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/ucnv.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/ucnv.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/udata/reader.vcxproj
+++ b/src/icu/source/samples/udata/reader.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\reader_x64_Debug/reader.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\reader_Win32_Debug/reader.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\reader_x64_Release/reader.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\reader_Win32_Release/reader.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/udata/writer.vcxproj
+++ b/src/icu/source/samples/udata/writer.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icutud.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/writer.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/writer.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icutu.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/writer.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/writer.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/samples/ugrep/ugrep.vcxproj
+++ b/src/icu/source/samples/ugrep/ugrep.vcxproj
@@ -153,7 +153,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/ugrep.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/ugrep.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -237,7 +237,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/ugrep.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/ugrep.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/samples/uresb/uresb.vcxproj
+++ b/src/icu/source/samples/uresb/uresb.vcxproj
@@ -146,7 +146,7 @@
       <AdditionalDependencies>icuuc.lib;icuio.lib;icutu.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/uresb.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64/;../../tools/toolutil/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64/;../../tools/toolutil/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/uresb.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -225,7 +225,7 @@
       <AdditionalDependencies>icuucd.lib;icuiod.lib;icutud.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/uresb.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib64/;../../tools/toolutil/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../lib\x64/;../../tools/toolutil/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/uresb.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/samples/ustring/ustring.vcxproj
+++ b/src/icu/source/samples/ustring/ustring.vcxproj
@@ -146,7 +146,7 @@
       <AdditionalDependencies>icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/ustring.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/ustring.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -225,7 +225,7 @@
       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/ustring.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/ustring.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/stubdata/stubdata.vcxproj
+++ b/src/icu/source/stubdata/stubdata.vcxproj
@@ -219,7 +219,7 @@
       <SetChecksum>true</SetChecksum>
       <BaseAddress>0x4ad00000</BaseAddress>
       <TurnOffAssemblyGeneration>true</TurnOffAssemblyGeneration>
-      <ImportLibrary>..\..\lib64\icudt.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icudt.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
@@ -263,7 +263,7 @@
       <SetChecksum>true</SetChecksum>
       <BaseAddress>0x4ad00000</BaseAddress>
       <TurnOffAssemblyGeneration>true</TurnOffAssemblyGeneration>
-      <ImportLibrary>..\..\lib64\icudt.lib</ImportLibrary>
+      <ImportLibrary>..\..\lib\x64\icudt.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>

--- a/src/icu/source/test/letest/cletest.vcxproj
+++ b/src/icu/source/test/letest/cletest.vcxproj
@@ -129,7 +129,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\lib64\icuucd.lib;..\..\..\lib64\icuind.lib;..\..\..\lib64\icutestd.lib;..\..\..\lib64\icutud.lib;..\..\..\lib64\iculed.lib;..\..\..\lib64\iculxd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\lib\x64\icuucd.lib;..\..\..\lib\x64\icuind.lib;..\..\..\lib\x64\icutestd.lib;..\..\..\lib\x64\icutud.lib;..\..\..\lib\x64\iculed.lib;..\..\..\lib\x64\iculxd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
@@ -149,7 +149,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\lib64\icuuc.lib;..\..\..\lib64\icuin.lib;..\..\..\lib64\icutest.lib;..\..\..\lib64\icutu.lib;..\..\..\lib64\icule.lib;..\..\..\lib64\iculx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\lib\x64\icuuc.lib;..\..\..\lib\x64\icuin.lib;..\..\..\lib\x64\icutest.lib;..\..\..\lib\x64\icutu.lib;..\..\..\lib\x64\icule.lib;..\..\..\lib\x64\iculx.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/src/icu/source/test/letest/gendata.vcxproj
+++ b/src/icu/source/test/letest/gendata.vcxproj
@@ -143,7 +143,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\lib64\iculed.lib;..\..\..\lib64\icuucd.lib;..\..\..\lib64\icutud.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\lib\x64\iculed.lib;..\..\..\lib\x64\icuucd.lib;..\..\..\lib\x64\icutud.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/gendata.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -220,7 +220,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\lib64\icule.lib;..\..\..\lib64\icuuc.lib;..\..\..\lib64\icutu.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\lib\x64\icule.lib;..\..\..\lib\x64\icuuc.lib;..\..\..\lib\x64\icutu.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/gendata.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ProgramDatabaseFile>.\x64\Release/gendata.pdb</ProgramDatabaseFile>

--- a/src/icu/source/test/perf/charperf/charperf.vcxproj
+++ b/src/icu/source/test/perf/charperf/charperf.vcxproj
@@ -151,7 +151,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;icutestd.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/charperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/charperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -235,7 +235,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/charperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/charperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/collperf/collperf.vcxproj
+++ b/src/icu/source/test/perf/collperf/collperf.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;icutud.lib;winmm.lib;icutestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/collperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/collperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -227,7 +227,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;icutest.lib;icutu.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/collperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/collperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/collperf2/collperf2.vcxproj
+++ b/src/icu/source/test/perf/collperf2/collperf2.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;icutud.lib;winmm.lib;icutestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/collperf2.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/collperf2.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -227,7 +227,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;icutest.lib;icutu.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/collperf2.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/collperf2.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/convperf/convperf.vcxproj
+++ b/src/icu/source/test/perf/convperf/convperf.vcxproj
@@ -151,7 +151,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/convperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/convperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -234,7 +234,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;icutestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/convperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/convperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/test/perf/normperf/dtfmtrtperf.vcxproj
+++ b/src/icu/source/test/perf/normperf/dtfmtrtperf.vcxproj
@@ -193,7 +193,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;icutestd.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/normperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/normperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -236,7 +236,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/normperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/normperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/normperf/normperf.vcxproj
+++ b/src/icu/source/test/perf/normperf/normperf.vcxproj
@@ -151,7 +151,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;icutestd.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/normperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/normperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -235,7 +235,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/normperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/normperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/strsrchperf/strsrchperf.vcxproj
+++ b/src/icu/source/test/perf/strsrchperf/strsrchperf.vcxproj
@@ -151,7 +151,7 @@
       <AdditionalDependencies>icuucd.lib;icuind.lib;icutud.lib;icutestd.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/strsrchperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/strsrchperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -235,7 +235,7 @@
       <AdditionalDependencies>icuuc.lib;icuin.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/strsrchperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/strsrchperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/ubrkperf/ubrkperf.vcxproj
+++ b/src/icu/source/test/perf/ubrkperf/ubrkperf.vcxproj
@@ -186,7 +186,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;icutestd.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/ubrkperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/ubrkperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -227,7 +227,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\..\..\..\bin64\ubrkperf24.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/ubrkperf24.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/unisetperf/unisetperf.vcxproj
+++ b/src/icu/source/test/perf/unisetperf/unisetperf.vcxproj
@@ -146,7 +146,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;winmm.lib;icutestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/unisetperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/unisetperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -226,7 +226,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/unisetperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/unisetperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/usetperf/usetperf.vcxproj
+++ b/src/icu/source/test/perf/usetperf/usetperf.vcxproj
@@ -147,7 +147,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;winmm.lib;icutest.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/usetperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/usetperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -224,7 +224,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;winmm.lib;icutestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/usetperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/usetperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/test/perf/ustrperf/stringperf.vcxproj
+++ b/src/icu/source/test/perf/ustrperf/stringperf.vcxproj
@@ -151,7 +151,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/stringperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/stringperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -234,7 +234,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;icutestd.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/stringperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/stringperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/src/icu/source/test/perf/utfperf/utfperf.vcxproj
+++ b/src/icu/source/test/perf/utfperf/utfperf.vcxproj
@@ -145,7 +145,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;winmm.lib;icutestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/utfperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/utfperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -225,7 +225,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/utfperf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/utfperf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/test/perf/utrie2perf/utrie2perf.vcxproj
+++ b/src/icu/source/test/perf/utrie2perf/utrie2perf.vcxproj
@@ -145,7 +145,7 @@
       <AdditionalDependencies>icuucd.lib;icutud.lib;winmm.lib;icutestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Debug/utrie2perf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\x64\Debug/utrie2perf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -225,7 +225,7 @@
       <AdditionalDependencies>icuuc.lib;icutu.lib;icutest.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\x64\Release/utrie2perf.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\..\lib64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\x64\Release/utrie2perf.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/src/icu/source/tools/ctestfw/ctestfw.vcxproj
+++ b/src/icu/source/tools/ctestfw/ctestfw.vcxproj
@@ -168,7 +168,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\..\lib64\icutest.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\..\lib\x64\icutest.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -193,10 +193,10 @@
     <Link>
       <OutputFile>..\..\..\bin64\icutest55.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <ProgramDatabaseFile>.\..\..\..\lib64\icutest.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\..\lib\x64\icutest.pdb</ProgramDatabaseFile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <ImportLibrary>.\..\..\..\lib64\icutest.lib</ImportLibrary>
+      <ImportLibrary>.\..\..\..\lib\x64\icutest.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
@@ -206,7 +206,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\..\lib64\icutestd.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\..\lib\x64\icutestd.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -234,8 +234,8 @@
       <OutputFile>..\..\..\bin64\icutest55d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\..\..\..\lib64\icutestd.pdb</ProgramDatabaseFile>
-      <ImportLibrary>.\..\..\..\lib64\icutestd.lib</ImportLibrary>
+      <ProgramDatabaseFile>.\..\..\..\lib\x64\icutestd.pdb</ProgramDatabaseFile>
+      <ImportLibrary>.\..\..\..\lib\x64\icutestd.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>

--- a/src/icu/source/tools/icuinfo/testplug.vcxproj
+++ b/src/icu/source/tools/icuinfo/testplug.vcxproj
@@ -170,7 +170,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\..\lib64\testplug.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\..\lib\x64\testplug.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -196,10 +196,10 @@
     <Link>
       <OutputFile>..\..\..\bin64\testplug.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <ProgramDatabaseFile>.\..\..\..\lib64\testplug.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\..\lib\x64\testplug.pdb</ProgramDatabaseFile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <ImportLibrary>.\..\..\..\lib64\testplug.lib</ImportLibrary>
+      <ImportLibrary>.\..\..\..\lib\x64\testplug.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
@@ -209,7 +209,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\..\lib64\testplugd.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\..\lib\x64\testplugd.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -238,8 +238,8 @@
       <OutputFile>..\..\..\bin64\testplug.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\..\..\..\lib64\testplugd.pdb</ProgramDatabaseFile>
-      <ImportLibrary>.\..\..\..\lib64\testplugd.lib</ImportLibrary>
+      <ProgramDatabaseFile>.\..\..\..\lib\x64\testplugd.pdb</ProgramDatabaseFile>
+      <ImportLibrary>.\..\..\..\lib\x64\testplugd.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>

--- a/src/icu/source/tools/toolutil/toolutil.vcxproj
+++ b/src/icu/source/tools/toolutil/toolutil.vcxproj
@@ -171,7 +171,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\..\lib64\icutu.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\..\lib\x64\icutu.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -196,12 +196,12 @@
     <Link>
       <OutputFile>..\..\..\bin64\icutu55.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <ProgramDatabaseFile>.\..\..\..\lib64\icutu.pdb</ProgramDatabaseFile>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>.\..\..\..\lib\x64\icutu.pdb</ProgramDatabaseFile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <BaseAddress>0x4ac00000</BaseAddress>
-      <ImportLibrary>..\..\..\lib64\icutu.lib</ImportLibrary>
+      <ImportLibrary>..\..\..\lib\x64\icutu.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
@@ -211,7 +211,7 @@
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TargetEnvironment>X64</TargetEnvironment>
-      <TypeLibraryName>.\..\..\..\lib64\icutud.tlb</TypeLibraryName>
+      <TypeLibraryName>.\..\..\..\lib\x64\icutud.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -237,11 +237,11 @@
     <Link>
       <OutputFile>..\..\..\bin64\icutu55d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>..\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\..\..\..\lib64\icutud.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\..\lib\x64\icutud.pdb</ProgramDatabaseFile>
       <BaseAddress>0x4ac00000</BaseAddress>
-      <ImportLibrary>..\..\..\lib64\icutud.lib</ImportLibrary>
+      <ImportLibrary>..\..\..\lib\x64\icutud.lib</ImportLibrary>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>

--- a/src/libjpeg-turbo/jpeg-static.vcxproj
+++ b/src/libjpeg-turbo/jpeg-static.vcxproj
@@ -173,6 +173,22 @@ xcopy /Y /R "$(ProjectDir)transupp.h" "$(SolutionDir)include"</Command>
       <PreprocessorDefinitions>WITH_SIMD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jconfig.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jdct.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jerror.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jinclude.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jmemsys.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jmorecfg.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jpegint.h " "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jpeglib.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jversion.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cdjpeg.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cderror.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)transupp.h" "$(SolutionDir)include"</Command>
+      <Message>Install Headers</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -180,6 +196,22 @@ xcopy /Y /R "$(ProjectDir)transupp.h" "$(SolutionDir)include"</Command>
       <PreprocessorDefinitions>WITH_SIMD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jconfig.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jdct.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jerror.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jinclude.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jmemsys.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jmorecfg.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jpegint.h " "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jpeglib.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)jversion.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cdjpeg.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)cderror.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)transupp.h" "$(SolutionDir)include"</Command>
+      <Message>Install Headers</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include=".\jcapimin.c" />
@@ -433,7 +465,7 @@ xcopy /Y /R "$(ProjectDir)transupp.h" "$(SolutionDir)include"</Command>
     </Object>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="C:/Development/Projects/WinCairoRequirements/src/libjpeg-turbo/build/simd/simd.vcxproj">
+    <ProjectReference Include="$(SolutionDir)src/libjpeg-turbo/simd/simd.vcxproj">
       <Project>53E75EB5-55C8-47B8-83AD-AB7A07F69818</Project>
     </ProjectReference>
   </ItemGroup>

--- a/src/make_distribution.vcxproj
+++ b/src/make_distribution.vcxproj
@@ -102,8 +102,8 @@ rm /f $(SolutionDir)bin\testzlib.*
     </Link>
     <PostBuildEvent>
       <Command>xcopy /Y "$(SolutionDir)src\icu\bin\*.dll" $(OutDir)
-copy /Y "$(SolutionDir)src\icu\lib\icuin.lib" "$(SolutionDir)lib32\libicuin.lib"
-copy /Y "$(SolutionDir)src\icu\lib\icuuc.lib" "$(SolutionDir)lib32\libicuuc.lib"
+copy /Y "$(SolutionDir)src\icu\lib\icuin.lib" "$(SolutionDir)lib\x86\libicuin.lib"
+copy /Y "$(SolutionDir)src\icu\lib\icuuc.lib" "$(SolutionDir)lib\x86\libicuuc.lib"
 
 del /f "$(OutDir)cal.*"
 del /f "$(OutDir)cintltst.*"
@@ -123,16 +123,16 @@ del /f "$(OutDir)icutu*.*"
 del /f "$(OutDir)testzlib.*"
 del /f "$(OutDir)uconv*.*"
 
-del /f "$(SolutionDir)lib32\ctestfw.*"
-del /f "$(SolutionDir)lib32\gen*.*"
-del /f "$(SolutionDir)lib32\icuio*.*"
-del /f "$(SolutionDir)lib32\icule*.*"
-del /f "$(SolutionDir)lib32\iculx*.*"
-del /f "$(SolutionDir)lib32\icutu*.*"
-del /f "$(SolutionDir)lib32\intltest.*"
-del /f "$(SolutionDir)lib32\letest.*"
-del /f "$(SolutionDir)lib32\pixman-1.*"
-del /f "$(SolutionDir)lib32\uconv*"
+del /f "$(SolutionDir)lib\x86\ctestfw.*"
+del /f "$(SolutionDir)lib\x86\gen*.*"
+del /f "$(SolutionDir)lib\x86\icuio*.*"
+del /f "$(SolutionDir)lib\x86\icule*.*"
+del /f "$(SolutionDir)lib\x86\iculx*.*"
+del /f "$(SolutionDir)lib\x86\icutu*.*"
+del /f "$(SolutionDir)lib\x86\intltest.*"
+del /f "$(SolutionDir)lib\x86\letest.*"
+del /f "$(SolutionDir)lib\x86\pixman-1.*"
+del /f "$(SolutionDir)lib\x86\uconv*"
 
 exit 0</Command>
     </PostBuildEvent>
@@ -165,8 +165,8 @@ rm /f $(SolutionDir)bin\testzlib.*
     </Link>
     <PostBuildEvent>
       <Command>xcopy /Y "$(SolutionDir)src\icu\bin64\*.dll" $(OutDir)
-copy /Y "$(SolutionDir)src\icu\lib64\icuin.lib" "$(SolutionDir)lib64\libicuin.lib"
-copy /Y "$(SolutionDir)src\icu\lib64\icuuc.lib" "$(SolutionDir)lib64\libicuuc.lib"
+copy /Y "$(SolutionDir)src\icu\lib\x64\icuin.lib" "$(SolutionDir)lib\x64\libicuin.lib"
+copy /Y "$(SolutionDir)src\icu\lib\x64\icuuc.lib" "$(SolutionDir)lib\x64\libicuuc.lib"
 
 del /f $(OutDir)cal.*
 del /f $(OutDir)cintltst.*
@@ -186,16 +186,16 @@ del /f $(OutDir)icutu*.*
 del /f $(OutDir)testzlib.*
 del /f $(OutDir)uconv*.*
 
-del /f $(SolutionDir)lib64\ctestfw.*
-del /f $(SolutionDir)lib64\gen*.*
-del /f $(SolutionDir)lib64\icuio*.*
-del /f $(SolutionDir)lib64\icule*.*
-del /f $(SolutionDir)lib64\iculx*.*
-del /f $(SolutionDir)lib64\icutu*.*
-del /f $(SolutionDir)lib64\intltest.*
-del /f $(SolutionDir)lib64\letest.*
-del /f $(SolutionDir)lib64\pixman-1.*
-del /f $(SolutionDir)lib64\uconv*
+del /f $(SolutionDir)lib\x64\ctestfw.*
+del /f $(SolutionDir)lib\x64\gen*.*
+del /f $(SolutionDir)lib\x64\icuio*.*
+del /f $(SolutionDir)lib\x64\icule*.*
+del /f $(SolutionDir)lib\x64\iculx*.*
+del /f $(SolutionDir)lib\x64\icutu*.*
+del /f $(SolutionDir)lib\x64\intltest.*
+del /f $(SolutionDir)lib\x64\letest.*
+del /f $(SolutionDir)lib\x64\pixman-1.*
+del /f $(SolutionDir)lib\x64\uconv*
 
 exit 0</Command>
     </PostBuildEvent>
@@ -203,8 +203,8 @@ exit 0</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PostBuildEvent>
       <Command>xcopy /Y "$(SolutionDir)src\icu\bin\*.dll" $(OutDir)
-copy /Y "$(SolutionDir)src\icu\lib\icuin.lib" "$(SolutionDir)lib32\libicuin.lib"
-copy /Y "$(SolutionDir)src\icu\lib\icuuc.lib" "$(SolutionDir)lib32\libicuuc.lib"
+copy /Y "$(SolutionDir)src\icu\lib\icuin.lib" "$(SolutionDir)lib\x86\libicuin.lib"
+copy /Y "$(SolutionDir)src\icu\lib\icuuc.lib" "$(SolutionDir)lib\x86\libicuuc.lib"
 
 del /f "$(OutDir)cal.*"
 del /f "$(OutDir)cintltst.*"
@@ -224,16 +224,16 @@ del /f "$(OutDir)icutu*.*"
 del /f "$(OutDir)testzlib.*"
 del /f "$(OutDir)uconv*.*"
 
-del /f "$(SolutionDir)lib32\ctestfw.*"
-del /f "$(SolutionDir)lib32\gen*.*"
-del /f "$(SolutionDir)lib32\icuio*.*"
-del /f "$(SolutionDir)lib32\icule*.*"
-del /f "$(SolutionDir)lib32\iculx*.*"
-del /f "$(SolutionDir)lib32\icutu*.*"
-del /f "$(SolutionDir)lib32\intltest.*"
-del /f "$(SolutionDir)lib32\letest.*"
-del /f "$(SolutionDir)lib32\pixman-1.*"
-del /f "$(SolutionDir)lib32\uconv*"
+del /f "$(SolutionDir)lib\x86\ctestfw.*"
+del /f "$(SolutionDir)lib\x86\gen*.*"
+del /f "$(SolutionDir)lib\x86\icuio*.*"
+del /f "$(SolutionDir)lib\x86\icule*.*"
+del /f "$(SolutionDir)lib\x86\iculx*.*"
+del /f "$(SolutionDir)lib\x86\icutu*.*"
+del /f "$(SolutionDir)lib\x86\intltest.*"
+del /f "$(SolutionDir)lib\x86\letest.*"
+del /f "$(SolutionDir)lib\x86\pixman-1.*"
+del /f "$(SolutionDir)lib\x86\uconv*"
 
 exit 0</Command>
     </PostBuildEvent>
@@ -241,8 +241,8 @@ exit 0</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PostBuildEvent>
       <Command>xcopy /Y "$(SolutionDir)src\icu\bin64\*.dll" $(OutDir)
-copy /Y "$(SolutionDir)src\icu\lib64\icuin.lib" "$(SolutionDir)lib64\libicuin.lib"
-copy /Y "$(SolutionDir)src\icu\lib64\icuuc.lib" "$(SolutionDir)lib64\libicuuc.lib"
+copy /Y "$(SolutionDir)src\icu\lib\x64\icuin.lib" "$(SolutionDir)lib\x64\libicuin.lib"
+copy /Y "$(SolutionDir)src\icu\lib\x64\icuuc.lib" "$(SolutionDir)lib\x64\libicuuc.lib"
 
 del /f $(OutDir)cal.*
 del /f $(OutDir)cintltst.*
@@ -262,16 +262,16 @@ del /f $(OutDir)icutu*.*
 del /f $(OutDir)testzlib.*
 del /f $(OutDir)uconv*.*
 
-del /f $(SolutionDir)lib64\ctestfw.*
-del /f $(SolutionDir)lib64\gen*.*
-del /f $(SolutionDir)lib64\icuio*.*
-del /f $(SolutionDir)lib64\icule*.*
-del /f $(SolutionDir)lib64\iculx*.*
-del /f $(SolutionDir)lib64\icutu*.*
-del /f $(SolutionDir)lib64\intltest.*
-del /f $(SolutionDir)lib64\letest.*
-del /f $(SolutionDir)lib64\pixman-1.*
-del /f $(SolutionDir)lib64\uconv*
+del /f $(SolutionDir)lib\x64\ctestfw.*
+del /f $(SolutionDir)lib\x64\gen*.*
+del /f $(SolutionDir)lib\x64\icuio*.*
+del /f $(SolutionDir)lib\x64\icule*.*
+del /f $(SolutionDir)lib\x64\iculx*.*
+del /f $(SolutionDir)lib\x64\icutu*.*
+del /f $(SolutionDir)lib\x64\intltest.*
+del /f $(SolutionDir)lib\x64\letest.*
+del /f $(SolutionDir)lib\x64\pixman-1.*
+del /f $(SolutionDir)lib\x64\uconv*
 
 exit 0</Command>
     </PostBuildEvent>

--- a/src/opencflite/objc4/objcrt/objcrt.vcxproj
+++ b/src/opencflite/objc4/objcrt/objcrt.vcxproj
@@ -81,7 +81,7 @@
       <Command>cl /nologo /c /MDd /D_DEBUG /D_BIND_TO_CURRENT_VCLIBS_VERSION /Od /Zl /DYNAMICBASE /GS /I"$(ProjectDir)\runtime" /I"$(SolutionDir)\include" /I"$(SolutionDir)\dist\include" /I"$(ProjectDir)\runtime" /D"_WINDOWS" /Dnil=0 ..\runtime\objcrt.c /Fo"$(OutDir)objcrt_debug.obj</Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>xcopy /Y /R "$(OutDir)objcrt_debug.obj" "$(SolutionDir)lib32"</Command>
+      <Command>xcopy /Y /R "$(OutDir)objcrt_debug.obj" "$(SolutionDir)lib\x86"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -89,7 +89,7 @@
       <Command>cl /nologo /c /MDd /D_DEBUG /D_BIND_TO_CURRENT_VCLIBS_VERSION /Od /Zl /DYNAMICBASE /GS /I"$(ProjectDir)\runtime" /I"$(SolutionDir)\include" /I"$(SolutionDir)\dist\include" /I"$(ProjectDir)\runtime" /D"_WINDOWS" /Dnil=0 ..\runtime\objcrt.c /Fo"$(OutDir)objcrt_debug.obj</Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>xcopy /Y /R "$(OutDir)objcrt_debug.obj" "$(SolutionDir)lib64"</Command>
+      <Command>xcopy /Y /R "$(OutDir)objcrt_debug.obj" "$(SolutionDir)lib\x64"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -97,7 +97,7 @@
       <Command>cl /nologo /c /MD /O1 /Zi /MP2 /D_BIND_TO_CURRENT_VCLIBS_VERSION /DYNAMICBASE /GS /I"$(ProjectDir)\runtime" /I"$(SolutionDir)\include" /I"$(SolutionDir)\dist\include" /I"$(ProjectDir)\..\runtime" /D"_WINDOWS" /Dnil=0 ..\runtime\objcrt.c /Fo"$(OutDir)objcrt.obj</Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>xcopy /Y /R "$(OutDir)objcrt.obj" "$(SolutionDir)lib32"</Command>
+      <Command>xcopy /Y /R "$(OutDir)objcrt.obj" "$(SolutionDir)lib\x86"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -105,7 +105,7 @@
       <Command>cl /nologo /c /MD /O1 /Zi /MP2 /D_BIND_TO_CURRENT_VCLIBS_VERSION /DYNAMICBASE /GS /I"$(ProjectDir)\runtime" /I"$(SolutionDir)\include" /I"$(SolutionDir)\dist\include" /I"$(ProjectDir)\..\runtime" /D"_WINDOWS" /Dnil=0 ..\runtime\objcrt.c /Fo"$(OutDir)objcrt.obj</Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>xcopy /Y /R "$(OutDir)objcrt.obj" "$(SolutionDir)lib64"</Command>
+      <Command>xcopy /Y /R "$(OutDir)objcrt.obj" "$(SolutionDir)lib\x64"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/openssl/openssl/openssl.vcxproj
+++ b/src/openssl/openssl/openssl.vcxproj
@@ -110,10 +110,10 @@ cmd /c ms\do_nasm.bat
 cmd /c nmake -f ms\ntdll.mak
 copy out32dll\libeay32.dll "$(OutDir)"
 copy out32dll\libeay32.pdb "$(OutDir)"
-copy out32dll\libeay32.lib "$(SolutionDir)\lib32"
+copy out32dll\libeay32.lib "$(SolutionDir)\lib\x86"
 copy out32dll\ssleay32.dll "$(OutDir)"
 copy out32dll\ssleay32.pdb "$(OutDir)"
-copy out32dll\ssleay32.lib "$(SolutionDir)\lib32"
+copy out32dll\ssleay32.lib "$(SolutionDir)\lib\x86"
 xcopy /Y "$(SolutionDir)src\openssl\inc32\openssl\*" "$(SolutionDir)include\openssl\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -134,10 +134,10 @@ cmd /c ms\do_win64a.bat
 cmd /c nmake -f ms\ntdll.mak
 copy out32dll\libeay32.dll "$(OutDir)"
 copy out32dll\libeay32.pdb "$(OutDir)"
-copy out32dll\libeay32.lib "$(SolutionDir)\lib64"
+copy out32dll\libeay32.lib "$(SolutionDir)\lib\x64"
 copy out32dll\ssleay32.dll "$(OutDir)"
 copy out32dll\ssleay32.pdb "$(OutDir)"
-copy out32dll\ssleay32.lib "$(SolutionDir)\lib64"
+copy out32dll\ssleay32.lib "$(SolutionDir)\lib\x64"
 xcopy /Y "$(SolutionDir)src\openssl\inc32\openssl\*" "$(SolutionDir)include\openssl\"
 </Command>
     </PostBuildEvent>
@@ -160,10 +160,10 @@ cmd /c ms\do_nasm.bat
 cmd /c nmake -f ms\ntdll.mak
 copy out32dll\libeay32.dll "$(OutDir)"
 copy out32dll\libeay32.pdb "$(OutDir)"
-copy out32dll\libeay32.lib "$(SolutionDir)\lib32"
+copy out32dll\libeay32.lib "$(SolutionDir)\lib\x86"
 copy out32dll\ssleay32.dll "$(OutDir)"
 copy out32dll\ssleay32.pdb "$(OutDir)"
-copy out32dll\ssleay32.lib "$(SolutionDir)\lib32"
+copy out32dll\ssleay32.lib "$(SolutionDir)\lib\x86"
 xcopy /Y "$(SolutionDir)src\openssl\inc32\openssl\*" "$(SolutionDir)include\openssl\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -184,10 +184,10 @@ cmd /c ms\do_win64a.bat
 cmd /c nmake -f ms\ntdll.mak
 copy out32dll\libeay32.dll "$(OutDir)"
 copy out32dll\libeay32.pdb "$(OutDir)"
-copy out32dll\libeay32.lib "$(SolutionDir)\lib64"
+copy out32dll\libeay32.lib "$(SolutionDir)\lib\x64"
 copy out32dll\ssleay32.dll "$(OutDir)"
 copy out32dll\ssleay32.pdb "$(OutDir)"
-copy out32dll\ssleay32.lib "$(SolutionDir)\lib64"
+copy out32dll\ssleay32.lib "$(SolutionDir)\lib\x64"
 xcopy /Y "$(SolutionDir)src\openssl\inc32\openssl\*" "$(SolutionDir)include\openssl\"
 </Command>
     </PostBuildEvent>

--- a/src/sqlite/sqlite/sqlite.vcxproj
+++ b/src/sqlite/sqlite/sqlite.vcxproj
@@ -97,9 +97,9 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\SQLite"
-xcopy /Y /R "$(ProjectDir)..\sqlite3.h" "$(SolutionDir)include\SQLite"
-xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include\SQLite"</Command>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\sqlite3.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -118,9 +118,9 @@ xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include\SQLite"</Comma
       <SubSystem>Windows</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\SQLite"
-xcopy /Y /R "$(ProjectDir)..\sqlite3.h" "$(SolutionDir)include\SQLite"
-xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include\SQLite"</Command>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\sqlite3.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -141,9 +141,9 @@ xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include\SQLite"</Comma
       <AdditionalIncludeDirectories>$(ProjectDir)\..\includes\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\SQLite"
-xcopy /Y /R "$(ProjectDir)..\sqlite3.h" "$(SolutionDir)include\SQLite"
-xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include\SQLite"</Command>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\sqlite3.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -163,9 +163,9 @@ xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include\SQLite"</Comma
       <AdditionalIncludeDirectories>$(ProjectDir)\..\includes\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\SQLite"
-xcopy /Y /R "$(ProjectDir)..\sqlite3.h" "$(SolutionDir)include\SQLite"
-xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include\SQLite"</Command>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\sqlite3.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\sqlite3ext.h" "$(SolutionDir)include"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/zlib/contrib/vstudio/vc10/zlibvc.vcxproj
+++ b/src/zlib/contrib/vstudio/vc10/zlibvc.vcxproj
@@ -109,14 +109,14 @@
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
-      <ImportLibrary>$(SolutionDir)lib32/zdll.lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x86/zdll.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zconf.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zlib.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zutil.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include\zlib"</Command>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zconf.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zlib.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zutil.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include"</Command>
       <Message>Install headers</Message>
     </PostBuildEvent>
     <MASM>
@@ -154,14 +154,14 @@ xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include\zlib"</Comma
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
-      <ImportLibrary>$(SolutionDir)lib32/zdll.lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x86/zdll.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zconf.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zlib.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zutil.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include\zlib"</Command>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zconf.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zlib.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zutil.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include"</Command>
       <Message>Install headers</Message>
     </PostBuildEvent>
     <MASM>
@@ -194,15 +194,15 @@ xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include\zlib"</Comma
     <Link>
       <ModuleDefinitionFile>.\zlibvc.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
-      <ImportLibrary>$(SolutionDir)lib64/zdll.lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x64/zdll.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
       <Message>Install headers</Message>
-      <Command>mkdir "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zconf.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zlib.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zutil.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include\zlib"</Command>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zconf.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zlib.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zutil.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -231,15 +231,15 @@ xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include\zlib"</Comma
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <ModuleDefinitionFile>.\zlibvc.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
-      <ImportLibrary>$(SolutionDir)lib64/zdll.lib</ImportLibrary>
+      <ImportLibrary>$(SolutionDir)lib\x64/zdll.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
       <Message>Install headers</Message>
-      <Command>mkdir "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zconf.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zlib.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\zutil.h" "$(SolutionDir)include\zlib"
-xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include\zlib"</Command>
+      <Command>mkdir "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zconf.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zlib.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\zutil.h" "$(SolutionDir)include"
+xcopy /Y /R "$(ProjectDir)..\..\..\gzguts.h" "$(SolutionDir)include"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This patch is to change wincairo's file structure to fit cmake's style. 
The goal is to use find_packages in webkit for wincairo's libraries.

To use find_package easily, the directory structure has to look like:
<prefix>/lib/<arch>
<prefix>/include/<arch> for libraries
With the old structure, every needed cmake find library script has to be added to webkit and modified to match libraries in the lib32 or lib64 structure.

The find library script also doesn't look in include/<name> for some libraries like zlib so I had to move those headers directly in the include directory.

Note: There's some whitespace changes too because some files have a combination of LF and CRLF line endings.
